### PR TITLE
Fix date/datetime decoding error during typecast

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ Requirements
 Before installing the adsdb interface please make sure the
 following components are installed on your system.
 
-- Python 2.4 or greater
+- Python 2.7 or greater (Python 3 is supported by this fork!)
 - Python ctypes module if missing
 - Advantage Database Server 10.1 or newer (Advantage Local Server works too)
 

--- a/adsdb.py
+++ b/adsdb.py
@@ -1,18 +1,18 @@
 #    Copyright 2010-2011 iAnywhere Solutions, Inc.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# 
+#
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# 
+#
 # While not a requirement of the license, if you do modify this file, we
 # would appreciate hearing about it.   Please email advantage@sybase.com
 
@@ -58,98 +58,99 @@ API_VERSION_EX = 2
 
 # NB: The following must match those in sacapi.h for the specified API_VERSION!
 
-A_INVALID_TYPE  = 0
-A_BINARY        = 1
-A_STRING        = 2
-A_DOUBLE        = 3
-A_VAL64         = 4
-A_UVAL64        = 5
-A_VAL32         = 6
-A_UVAL32        = 7
-A_VAL16         = 8
-A_UVAL16        = 9
-A_VAL8          = 10
-A_UVAL8         = 11
-A_NCHAR         = 12
-A_DECIMAL       = 13
-A_DATE          = 14
-A_TIME          = 15
-A_TIMESTAMP     = 16
+A_INVALID_TYPE = 0
+A_BINARY = 1
+A_STRING = 2
+A_DOUBLE = 3
+A_VAL64 = 4
+A_UVAL64 = 5
+A_VAL32 = 6
+A_UVAL32 = 7
+A_VAL16 = 8
+A_UVAL16 = 9
+A_VAL8 = 10
+A_UVAL8 = 11
+A_NCHAR = 12
+A_DECIMAL = 13
+A_DATE = 14
+A_TIME = 15
+A_TIMESTAMP = 16
 
-DT_NOTYPE       = 0
-DT_DATE         = 384
-DT_TIME         = 388
-DT_TIMESTAMP    = 392
-DT_VARCHAR      = 448
-DT_FIXCHAR      = 452
-DT_LONGVARCHAR  = 456
-DT_STRING       = 460
-DT_DOUBLE       = 480
-DT_FLOAT        = 482
-DT_DECIMAL      = 484
-DT_INT          = 496
-DT_SMALLINT     = 500
-DT_BINARY       = 524
-DT_LONGBINARY   = 528
-DT_TINYINT      = 604
-DT_BIGINT       = 608
-DT_UNSINT       = 612
-DT_UNSSMALLINT  = 616
-DT_UNSBIGINT    = 620
-DT_BIT          = 624
-DT_NSTRING      = 628
-DT_NFIXCHAR     = 632
-DT_NVARCHAR     = 636
+DT_NOTYPE = 0
+DT_DATE = 384
+DT_TIME = 388
+DT_TIMESTAMP = 392
+DT_VARCHAR = 448
+DT_FIXCHAR = 452
+DT_LONGVARCHAR = 456
+DT_STRING = 460
+DT_DOUBLE = 480
+DT_FLOAT = 482
+DT_DECIMAL = 484
+DT_INT = 496
+DT_SMALLINT = 500
+DT_BINARY = 524
+DT_LONGBINARY = 528
+DT_TINYINT = 604
+DT_BIGINT = 608
+DT_UNSINT = 612
+DT_UNSSMALLINT = 616
+DT_UNSBIGINT = 620
+DT_BIT = 624
+DT_NSTRING = 628
+DT_NFIXCHAR = 632
+DT_NVARCHAR = 636
 DT_LONGNVARCHAR = 640
 
-DD_INVALID      = 0x0
-DD_INPUT        = 0x1
-DD_OUTPUT       = 0x2
+DD_INVALID = 0x0
+DD_INPUT = 0x1
+DD_OUTPUT = 0x2
 DD_INPUT_OUTPUT = 0x3
+
 
 class DataValue(Structure):
     """Must match a_ads_data_value."""
 
-    _fields_ = [("buffer",      POINTER(c_char)),
+    _fields_ = [("buffer", POINTER(c_char)),
                 ("buffer_size", c_size_t),
-                ("length",      POINTER(c_size_t)),
-                ("type",        c_int),
-                ("is_null",     POINTER(c_int))]
+                ("length", POINTER(c_size_t)),
+                ("type", c_int),
+                ("is_null", POINTER(c_int))]
 
 
 class BindParam(Structure):
     """Must match a_ads_bind_param."""
 
-    _fields_ = [("direction",   c_int),
-                ("value",       DataValue),
-                ("name",        c_char_p)]
+    _fields_ = [("direction", c_int),
+                ("value", DataValue),
+                ("name", c_char_p)]
 
 
 class ColumnInfo(Structure):
     """Must match a_ads_column_info."""
 
-    _fields_ = [("name",        c_char_p),
-                ("type",        c_int),
+    _fields_ = [("name", c_char_p),
+                ("type", c_int),
                 ("native_type", c_int),
-                ("precision",   c_short),
-                ("scale",       c_short),
-                ("max_size",    c_int),
-                ("nullable",    c_int)]
+                ("precision", c_short),
+                ("scale", c_short),
+                ("max_size", c_int),
+                ("nullable", c_int)]
 
 
 class DataInfo(Structure):
     """Must match a_ads_data_info."""
 
-    _fields_ = [("index",       c_int),
-                ("type",        c_int),
-                ("is_null",     c_int),
-                ("data_size",   c_size_t)]
+    _fields_ = [("index", c_int),
+                ("type", c_int),
+                ("is_null", c_int),
+                ("data_size", c_size_t)]
+
 
 # NB: The preceding must match those in sacapi.h for the specified API_VERSION!
 
 
 class DBAPISet(frozenset):
-
     """A special type of set for which A == x is true if A is a
     DBAPISet and x is a member of that set."""
 
@@ -163,82 +164,92 @@ class DBAPISet(frozenset):
         return not self == other
 
 
-STRING    = DBAPISet([A_STRING,A_NCHAR])
-BINARY    = DBAPISet([A_BINARY])
-NUMBER    = DBAPISet([A_DOUBLE,
-                      A_VAL64,
-                      A_UVAL64,
-                      A_VAL32,
-                      A_UVAL32,
-                      A_VAL16,
-                      A_UVAL16,
-                      A_VAL8,
-                      A_UVAL8,
-                      A_DECIMAL])
-DATE      = DBAPISet([A_DATE])
-TIME      = DBAPISet([A_TIME])
+STRING = DBAPISet([A_STRING, A_NCHAR])
+BINARY = DBAPISet([A_BINARY])
+NUMBER = DBAPISet([A_DOUBLE,
+                   A_VAL64,
+                   A_UVAL64,
+                   A_VAL32,
+                   A_UVAL32,
+                   A_VAL16,
+                   A_UVAL16,
+                   A_VAL8,
+                   A_UVAL8,
+                   A_DECIMAL])
+DATE = DBAPISet([A_DATE])
+TIME = DBAPISet([A_TIME])
 TIMESTAMP = DBAPISet([A_TIMESTAMP])
-DATETIME  = TIMESTAMP
-ROWID     = DBAPISet()
+DATETIME = TIMESTAMP
+ROWID = DBAPISet()
 
-ToPyType = {DT_DATE         : DATE,
-            DT_TIME         : TIME,
-            DT_TIMESTAMP    : TIMESTAMP,
-            DT_VARCHAR      : STRING,
-            DT_FIXCHAR      : STRING,
-            DT_LONGVARCHAR  : STRING,
-            DT_STRING       : STRING,
-            DT_DOUBLE       : NUMBER,
-            DT_FLOAT        : NUMBER,
-            DT_DECIMAL      : NUMBER,
-            DT_INT          : NUMBER,
-            DT_SMALLINT     : NUMBER,
-            DT_BINARY       : BINARY,
-            DT_LONGBINARY   : BINARY,
-            DT_TINYINT      : NUMBER,
-            DT_BIGINT       : NUMBER,
-            DT_UNSINT       : NUMBER,
-            DT_UNSSMALLINT  : NUMBER,
-            DT_UNSBIGINT    : NUMBER,
-            DT_BIT          : NUMBER,
-            DT_LONGNVARCHAR : STRING,
-            DT_NSTRING      : STRING,
-            DT_NFIXCHAR     : STRING,
-            DT_NVARCHAR     : STRING}
+ToPyType = {DT_DATE: DATE,
+            DT_TIME: TIME,
+            DT_TIMESTAMP: TIMESTAMP,
+            DT_VARCHAR: STRING,
+            DT_FIXCHAR: STRING,
+            DT_LONGVARCHAR: STRING,
+            DT_STRING: STRING,
+            DT_DOUBLE: NUMBER,
+            DT_FLOAT: NUMBER,
+            DT_DECIMAL: NUMBER,
+            DT_INT: NUMBER,
+            DT_SMALLINT: NUMBER,
+            DT_BINARY: BINARY,
+            DT_LONGBINARY: BINARY,
+            DT_TINYINT: NUMBER,
+            DT_BIGINT: NUMBER,
+            DT_UNSINT: NUMBER,
+            DT_UNSSMALLINT: NUMBER,
+            DT_UNSBIGINT: NUMBER,
+            DT_BIT: NUMBER,
+            DT_LONGNVARCHAR: STRING,
+            DT_NSTRING: STRING,
+            DT_NFIXCHAR: STRING,
+            DT_NVARCHAR: STRING}
+
 
 class Error(StandarError):
     pass
+
 
 class Warning(StandarError):
     """Raise for important warnings like data truncation while inserting."""
     pass
 
+
 class InterfaceError(Error):
     """Raise for interface, not database, related errors."""
     pass
 
+
 class DatabaseError(Error):
     pass
+
 
 class InternalError(DatabaseError):
     """Raise for internal errors: cursor not valid, etc."""
     pass
+
 
 class OperationalError(DatabaseError):
     """Raise for database related errors, not under programmer's control:
     unexpected disconnect, memory allocation error, etc."""
     pass
 
+
 class ProgrammingError(DatabaseError):
     """Raise for programming errors: table not found, incorrect syntax, etc."""
     pass
+
 
 class IntegrityError(DatabaseError):
     """Raise for database constraint failures:  missing primary key, etc."""
     pass
 
+
 class DataError(DatabaseError):
     pass
+
 
 class NotSupportedError(DatabaseError):
     """Raise for methods or APIs not supported by database."""
@@ -247,31 +258,34 @@ class NotSupportedError(DatabaseError):
 
 format = 'xxxdqQiIhHbBxxxx'
 
-def mk_valueof(raw, char_set):
+
+def mk_valueof(raw, char_set, string_char_set):
     def valueof(data):
         if data.is_null.contents:
             return None
         elif data.type in raw:
             return data.buffer[:data.length.contents.value]
         elif data.type in (A_STRING,):
-            return data.buffer[:data.length.contents.value].decode(char_set)
+            return data.buffer[:data.length.contents.value].decode(string_char_set)
         elif data.type in (A_NCHAR,):
-            return unicode( data.buffer[:data.length.contents.value], char_set )
+            return unicode(data.buffer[:data.length.contents.value], char_set)
         elif data.type in (A_DECIMAL,):
             # Numeric fields come out as strings, convert them to decimal.Decimal objects
-            return Decimal( data.buffer[:data.length.contents.value])
+            return Decimal(data.buffer[:data.length.contents.value])
         elif data.type in (A_DATE,):
             # Date fields come out as string, convert them to datetime.date objects
-            return ads_typecast_date( data.buffer[:data.length.contents.value] )
+            return ads_typecast_date(data.buffer[:data.length.contents.value])
         elif data.type in (A_TIME,):
             # Time fields come out as string, convert them to datetime.time objects
-            return ads_typecast_time( data.buffer[:data.length.contents.value] )
+            return ads_typecast_time(data.buffer[:data.length.contents.value])
         elif data.type in (A_TIMESTAMP,):
             # Timestamp fields come out as string, convert them to datetime.time objects
-            return ads_typecast_timestamp( data.buffer[:data.length.contents.value] )
+            return ads_typecast_timestamp(
+                data.buffer[:data.length.contents.value])
         else:
             fmt = format[data.type]
             return unpack(fmt, data.buffer[:calcsize(fmt)])[0]
+
     return valueof
 
 
@@ -311,28 +325,31 @@ def mk_assign(char_set):
         param.value.buffer = cast(buffer, POINTER(c_char))
         param.value.buffer_size = c_size_t(size)
         param.value.length = pointer(c_size_t(length))
+
     return assign
 
 
 threadsafety = 1
-apilevel     = '2.0'
-paramstyle   = 'qmark'
+apilevel = '2.0'
+paramstyle = 'qmark'
 
-__all__ = [ 'threadsafety', 'apilevel', 'paramstyle', 'connect'] 
+__all__ = ['threadsafety', 'apilevel', 'paramstyle', 'connect']
 
 if platform.system() == 'Windows':
     bIsWindows = True
 elif platform.system() == 'Linux':
     bIsWindows = False
 else:
-    raise InterfaceError( "Could not determine operating system type (Windows or Linux)." )
+    raise InterfaceError(
+        "Could not determine operating system type (Windows or Linux).")
 
 if calcsize("P") * 8 == 64:
     bIs64Bit = True
 elif calcsize("P") * 8 == 32:
     bIs64Bit = False
 else:
-    raise InterfaceError( "Could not determine Python architecture type (64 or 32 bit)." )
+    raise InterfaceError(
+        "Could not determine Python architecture type (64 or 32 bit).")
 
 if bIsWindows == False:
     strACELibrary = 'libace.so'
@@ -340,6 +357,7 @@ elif bIs64Bit == True:
     strACELibrary = 'ace64.dll'
 else:
     strACELibrary = 'ace32.dll'
+
 
 def load_library(*names):
     for name in names:
@@ -362,18 +380,22 @@ class Root(object):
             context = self.api.ads_init_ex(name, API_VERSION_EX, byref(ver))
             if not context or ver.value != API_VERSION_EX:
                 raise InterfaceError("dbcapi version %d required." %
-                        API_VERSION_EX)
+                                     API_VERSION_EX)
+
             def new_connection():
                 return self.api.ads_new_connection_ex(context)
+
             self.api.ads_new_connection = new_connection
+
             def fini():
                 self.api.ads_fini_ex(context)
+
             self.api.ads_fini = fini
         except:
             if (not self.api.ads_init(name, API_VERSION, byref(ver)) or
-                ver.value != API_VERSION):
+                        ver.value != API_VERSION):
                 raise InterfaceError("dbcapi version %d required." %
-                        API_VERSION)
+                                     API_VERSION)
             self.api.ads_new_connection.restype = POINTER(c_int)
         # Need to set return type to some pointer type other than void
         # to avoid automatic conversion to a (32 bit) int.
@@ -390,8 +412,7 @@ def connect(*args, **kwargs):
 
 
 class Connection(object):
-
-    def __init__(self, args, kwargs, parent = Root("PYTHON")):
+    def __init__(self, args, kwargs, parent=Root("PYTHON")):
 
         self.Error = Error
         self.Warning = Warning
@@ -407,11 +428,11 @@ class Connection(object):
 
         self.parent, self.api = parent, parent.api
         char_set = 'utf-16'
-        params = ';'.join( kw + '=' + arg for kw, arg in kwargs.items())
+        params = ';'.join(kw + '=' + arg for kw, arg in kwargs.items())
         if isinstance(params, unicode):
             params = params.encode('utf-8')
 
-        self.valueof = mk_valueof((A_BINARY,), char_set)
+        self.valueof = mk_valueof((A_BINARY,), char_set, 'cp1252')
         self.assign = mk_assign(char_set)
         self.char_set = char_set
         self.c = self.api.ads_new_connection()
@@ -434,7 +455,7 @@ class Connection(object):
             raise self.InterfaceError("not connected")
         return self.c
 
-    def begin_transaction (self):
+    def begin_transaction(self):
         return self.api.AdsBeginTransaction(self.con())
 
     def commit(self):
@@ -452,7 +473,7 @@ class Connection(object):
     def error(self):
         buf = create_string_buffer(512)
         rc = self.api.ads_error(self.con(), buf, sizeof(buf))
-        if rc in (-193,-194,-195,-196):
+        if rc in (-193, -194, -195, -196):
             return IntegrityError(buf.value)
         else:
             return OperationalError(buf.value)
@@ -474,7 +495,8 @@ class Connection(object):
         self.cursors.add(x)
         return x
 
-    def __enter__(self): return self.cursor()
+    def __enter__(self):
+        return self.cursor()
 
     def __exit__(self, exc, value, tb):
         if exc:
@@ -484,12 +506,13 @@ class Connection(object):
 
 class Cursor(object):
     class TypeConverter(object):
-        def __init__(self,types):
+        def __init__(self, types):
             def find_converter(t):
                 return CONVERSION_CALLBACKS.get(t, lambda x: x)
+
             self.converters = list(map(find_converter, types))
 
-        def gen(self,values):
+        def gen(self, values):
             for converter, value in zip(self.converters, values):
                 yield converter(value)
 
@@ -529,11 +552,14 @@ class Cursor(object):
 
     def new_statement(self, operation):
         self.free_statement()
-        if isinstance( operation, unicode ):
-            operation = operation.encode( "utf-16" ) + b'\x00'  # +b'\x00' since ACE needs 2 NULL chars for utf-16
-            self.stmt = self.api.ads_prepare(self.con(), operation, True ) # True unicode utf-16
+        if isinstance(operation, unicode):
+            operation = operation.encode(
+                "utf-16") + b'\x00'  # +b'\x00' since ACE needs 2 NULL chars for utf-16
+            self.stmt = self.api.ads_prepare(self.con(), operation,
+                                             True)  # True unicode utf-16
         else:
-            self.stmt = self.api.ads_prepare(self.con(), operation, False ) # False, not unicode
+            self.stmt = self.api.ads_prepare(self.con(), operation,
+                                             False)  # False, not unicode
 
     def free_statement(self):
         if self.__stmt:
@@ -555,19 +581,20 @@ class Cursor(object):
         info = ColumnInfo()
         for i in range(self.api.ads_num_cols(self.get_stmt())):
             self.api.ads_get_column_info(self.get_stmt(), i, byref(info))
-            if info.native_type in [DT_NSTRING,DT_NFIXCHAR,DT_NVARCHAR,DT_LONGNVARCHAR]:
+            if info.native_type in [DT_NSTRING, DT_NFIXCHAR, DT_NVARCHAR,
+                                    DT_LONGNVARCHAR]:
                 # Precision and size here are in bytes, so convert it to chars
                 # for unicode fields
                 info.precision = info.precision // 2
                 info.max_size = info.max_size // 2
-            yield ((info.name,
-                   ToPyType[info.native_type],
-                   None,
-                   info.max_size,
-                   info.precision,
-                   info.scale,
-                   info.nullable,
-                   info.native_type),
+            yield ((info.name.decode('ascii'),
+                    ToPyType[info.native_type],
+                    None,
+                    info.max_size,
+                    info.precision,
+                    info.scale,
+                    info.nullable,
+                    info.native_type),
                    info.native_type)
 
     def executemany(self, operation, seq_of_parameters):
@@ -597,7 +624,7 @@ class Cursor(object):
                     rowcount = self.api.ads_affected_rows(self.stmt)
                     self.description = None
                     self.converter = None
-    
+
                 if rowcount < 0:
                     # Can happen if number of rows is only an estimate
                     self.rowcount = -1
@@ -611,11 +638,12 @@ class Cursor(object):
             raise self.parent.error()
         return [(self.valueof)(param.value) for param in parms]
 
-    def execute(self, operation, parameters = ()):
+    def execute(self, operation, parameters=()):
         self.executemany(operation, [parameters])
 
-    def callproc(self, procname, parameters = ()):
-        stmt = 'EXECUTE PROCEDURE '+procname+'('+','.join(len(parameters)*('?',))+')'
+    def callproc(self, procname, parameters=()):
+        stmt = 'EXECUTE PROCEDURE ' + procname + '(' + ','.join(
+            len(parameters) * ('?',)) + ')'
         return self.executemany(stmt, [parameters])
 
     def values(self):
@@ -636,7 +664,7 @@ class Cursor(object):
     def fetchmany(self, size=None):
         if size is None:
             size = self.arraysize
-        return [row for i,row in zip(xrange(size), self.rows())]
+        return [row for i, row in zip(xrange(size), self.rows())]
 
     def fetchone(self):
         rows = self.fetchmany(size=1)
@@ -655,30 +683,37 @@ class Cursor(object):
 
 
 def Date(*ymd):
-    return "%04d/%02d/%02d"%ymd
+    return "%04d/%02d/%02d" % ymd
+
 
 def Time(*hms):
-    return "%02d:%02d:%02d"%hms
+    return "%02d:%02d:%02d" % hms
+
 
 def Timestamp(*ymdhms):
-    return "%04d/%02d/%02d %02d:%02d:%02d"%ymdhms
+    return "%04d/%02d/%02d %02d:%02d:%02d" % ymdhms
+
 
 def DateFromTicks(ticks):
     return Date(*time.localtime(ticks)[:3])
 
+
 def TimeFromTicks(ticks):
     return Time(*time.localtime(ticks)[3:6])
+
 
 def TimestampFromTicks(ticks):
     return Timestamp(*time.localtime(ticks)[:6])
 
-class Binary( bytes ):
+
+class Binary(bytes):
     pass
 
-def ads_typecast_timestamp (s):
+
+def ads_typecast_timestamp(s):
     "Custom timestamp converter for ADS since it uses a different string format"
     if not s: return None
-    if isinstance( s, datetime.datetime ):
+    if isinstance(s, datetime.datetime):
         return s
     if not ' ' in s: return typecast_date(s)
 
@@ -694,24 +729,28 @@ def ads_typecast_timestamp (s):
     if ampm == 'PM':
         hour += 12
 
-    if '.' in seconds: # check whether seconds have a fractional part
+    if '.' in seconds:  # check whether seconds have a fractional part
         seconds, microseconds = seconds.split('.')
     else:
         microseconds = '0'
 
     return datetime.datetime(int(dates[2]), int(dates[0]), int(dates[1]),
-        hour, int(times[1]), int(seconds), int((microseconds + '000000')[:6]))
+                             hour, int(times[1]), int(seconds),
+                             int((microseconds + '000000')[:6]))
+
 
 def ads_typecast_date(s):
     "Custom date converter for ADS since it uses a different string format"
     if not s: return None
-    if isinstance( s, datetime.date ):
+    if isinstance(s, datetime.date):
         return s
 
     m, d, y = s.split('/')
-    return s and datetime.date(int(y), int(m), int(d)) or None # returns None if s is null
+    return s and datetime.date(int(y), int(m),
+                               int(d)) or None  # returns None if s is null
 
-def ads_typecast_time(s): # does NOT store time zone information
+
+def ads_typecast_time(s):  # does NOT store time zone information
     "Custom time converter for ADS since it uses a different string format"
     if not s: return None
     if isinstance(s, datetime.time): return s
@@ -726,13 +765,17 @@ def ads_typecast_time(s): # does NOT store time zone information
     if ampm == 'PM':
         iHour += 12
 
-    if '.' in seconds: # check whether seconds have a fractional part
+    if '.' in seconds:  # check whether seconds have a fractional part
         seconds, microseconds = seconds.split('.')
     else:
         microseconds = '0'
 
-    return datetime.time(iHour, int(minutes), int(seconds), int(float('.'+microseconds) * 1000000))
+    return datetime.time(iHour, int(minutes), int(seconds),
+                         int(float('.' + microseconds) * 1000000))
+
 
 CONVERSION_CALLBACKS = {}
+
+
 def register_converter(datatype, callback):
     CONVERSION_CALLBACKS[datatype] = callback

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #######################################################################
 # Copyright 1994-2011 iAnywhere Solutions, Inc.  All rights reserved.
 # This sample code is provided AS IS, without warranty or liability
@@ -15,9 +16,9 @@ import adsdb
 conn = adsdb.connect(DataSource='c:\\', ServerType='local or remote')
 cur = conn.cursor()
 
-cur.execute("select 'Hello World' from system.iota")
-assert cur.fetchone()[0] > 0
+cur.execute(u"select 'Hellö Wörld' from system.iota")
+assert cur.fetchone()[0] == u'Hellö Wörld'
 
 conn.close()
-print 'adsdb successfully installed.'
+print('adsdb successfully installed.')
 


### PR DESCRIPTION
Deserializing data types to `datetime.datetime` and `datetime.date` raised `TypeError: a bytes-like object is required, not 'str'` for me with Python 3.x – adding the proper decoding fixed the issue.

Other data types might also have this issue; but don't have a table with the according columns.

Also thanks for this repo.